### PR TITLE
Add JSON beautifier tool and tests

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders welcome message', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const textElement = screen.getByText(/Welcome to My Website/i);
+  expect(textElement).toBeInTheDocument();
 });

--- a/src/pages/tools/JsonBeautifier.js
+++ b/src/pages/tools/JsonBeautifier.js
@@ -1,14 +1,66 @@
 // JsonBeautifier.js
 
-import React from 'react';
+import React, { useState } from 'react';
 
 const JsonBeautifier = () => {
+  const [rawJson, setRawJson] = useState('');
+  const [formattedJson, setFormattedJson] = useState('');
+  const [error, setError] = useState('');
+
+  const handleBeautify = () => {
+    try {
+      const parsed = JSON.parse(rawJson);
+      const pretty = JSON.stringify(parsed, null, 2);
+      setFormattedJson(pretty);
+      setError('');
+    } catch {
+      setError('Invalid JSON');
+      setFormattedJson('');
+    }
+  };
+
+  const handleCopy = async () => {
+    if (formattedJson && navigator.clipboard) {
+      try {
+        await navigator.clipboard.writeText(formattedJson);
+      } catch {
+        // ignore copy errors
+      }
+    }
+  };
+
   return (
     <div>
       <h2>JSON Beautifier</h2>
-      <p>This is the JSON Beautifier page content.</p>
+      <div>
+        <label htmlFor="json-input">JSON Input</label>
+        <textarea
+          id="json-input"
+          value={rawJson}
+          onChange={(e) => setRawJson(e.target.value)}
+          rows={10}
+          cols={50}
+          placeholder="Paste JSON here"
+        ></textarea>
+      </div>
+      <div>
+        <button onClick={handleBeautify}>Beautify JSON</button>
+        {formattedJson && (
+          <button onClick={handleCopy} style={{ marginLeft: '0.5rem' }}>
+            Copy to Clipboard
+          </button>
+        )}
+      </div>
+      {error && (
+        <p role="alert" style={{ color: 'red' }}>
+          {error}
+        </p>
+      )}
+      {formattedJson && (
+        <pre data-testid="formatted-json">{formattedJson}</pre>
+      )}
     </div>
   );
-}
+};
 
 export default JsonBeautifier;

--- a/src/pages/tools/JsonBeautifier.test.js
+++ b/src/pages/tools/JsonBeautifier.test.js
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import JsonBeautifier from './JsonBeautifier';
+
+test('formats valid JSON', () => {
+  render(<JsonBeautifier />);
+  const input = screen.getByLabelText(/JSON Input/i);
+  fireEvent.change(input, { target: { value: '{"a":1}' } });
+  fireEvent.click(screen.getByText(/Beautify JSON/i));
+  const output = screen.getByTestId('formatted-json');
+  expect(output).toHaveTextContent('"a": 1');
+});
+
+test('shows error for invalid JSON', () => {
+  render(<JsonBeautifier />);
+  const input = screen.getByLabelText(/JSON Input/i);
+  fireEvent.change(input, { target: { value: '{invalid}' } });
+  fireEvent.click(screen.getByText(/Beautify JSON/i));
+  expect(screen.getByRole('alert')).toHaveTextContent(/Invalid JSON/i);
+  expect(screen.queryByTestId('formatted-json')).toBeNull();
+});
+
+test('copies formatted JSON to clipboard', () => {
+  Object.assign(navigator, {
+    clipboard: { writeText: jest.fn() },
+  });
+
+  render(<JsonBeautifier />);
+  const input = screen.getByLabelText(/JSON Input/i);
+  fireEvent.change(input, { target: { value: '{"a":1}' } });
+  fireEvent.click(screen.getByText(/Beautify JSON/i));
+  fireEvent.click(screen.getByText(/Copy to Clipboard/i));
+  const expected = JSON.stringify({ a: 1 }, null, 2);
+  expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expected);
+});


### PR DESCRIPTION
## Summary
- implement interactive JSON beautifier with error handling
- add labeled input and copy-to-clipboard support
- expand tests for invalid JSON and clipboard copy

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688e6933900483258fb1826e71954b7e