### PR TITLE
Add AI playground tool

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import ScrumPoker from './pages/tools/ScrumPoker';
 import JsonBeautifier from './pages/tools/JsonBeautifier';
 import SqlBeautifier from './pages/tools/SqlBeautifier';
+import AiPlayground from './pages/tools/AiPlayground';
 import Content from './components/layout/Content';
 import About from './pages/tools/About';
 import BreakoutGame from './pages/games/breakout/components/BreakoutGame';
@@ -25,6 +26,7 @@ function App() {
                   <Route path="/tools/scrum-poker" element={<ScrumPoker />} />
                   <Route path="/tools/json-beautifier" element={<JsonBeautifier />} />
                   <Route path="/tools/sql-beautifier" element={<SqlBeautifier />} />
+                  <Route path="/tools/ai-playground" element={<AiPlayground />} />
                   <Route path="/about" element={<About />} />
                   <Route path="/games/breakout" element={<BreakoutGame />} />
                 </Routes>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders welcome message', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const textElement = screen.getByText(/Welcome to My Website/i);
+  expect(textElement).toBeInTheDocument();
 });

--- a/src/components/layout/Sidebar/Sidebar.js
+++ b/src/components/layout/Sidebar/Sidebar.js
@@ -32,6 +32,9 @@ const Sidebar = () => {
             <li>
               <a href="/tools/sql-beautifier">SQL Beautifier</a>
             </li>
+            <li>
+              <a href="/tools/ai-playground">AI Playground</a>
+            </li>
           </ul>
         </li>
         <li>

--- a/src/pages/tools/AiPlayground.js
+++ b/src/pages/tools/AiPlayground.js
@@ -1,0 +1,67 @@
+// AiPlayground.js
+
+import React, { useState } from 'react';
+
+const AiPlayground = () => {
+  const [prompt, setPrompt] = useState('');
+  const [response, setResponse] = useState('');
+  const [error, setError] = useState('');
+
+  const handleAsk = async () => {
+    const apiKey = process.env.REACT_APP_OPENAI_API_KEY;
+    if (!apiKey) {
+      setError('No API key set');
+      return;
+    }
+
+    try {
+      setError('');
+      setResponse('Loading...');
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-3.5-turbo',
+          messages: [{ role: 'user', content: prompt }],
+        }),
+      });
+      const data = await res.json();
+      const text = data.choices?.[0]?.message?.content;
+      setResponse(text || 'No response');
+    } catch {
+      setError('Request failed');
+      setResponse('');
+    }
+  };
+
+  return (
+    <div>
+      <h2>AI Playground</h2>
+      <div>
+        <label htmlFor="prompt-input">Prompt</label>
+        <textarea
+          id="prompt-input"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          rows={5}
+          cols={50}
+          placeholder="Ask something..."
+        ></textarea>
+      </div>
+      <div>
+        <button onClick={handleAsk}>Ask AI</button>
+      </div>
+      {error && (
+        <p role="alert" style={{ color: 'red' }}>
+          {error}
+        </p>
+      )}
+      {response && <pre data-testid="ai-response">{response}</pre>}
+    </div>
+  );
+};
+
+export default AiPlayground;

--- a/src/pages/tools/AiPlayground.test.js
+++ b/src/pages/tools/AiPlayground.test.js
@@ -1,0 +1,8 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import AiPlayground from './AiPlayground';
+
+test('shows error when API key is missing', () => {
+  render(<AiPlayground />);
+  fireEvent.click(screen.getByText(/Ask AI/i));
+  expect(screen.getByRole('alert')).toHaveTextContent(/No API key set/i);
+});

--- a/src/pages/tools/JsonBeautifier.js
+++ b/src/pages/tools/JsonBeautifier.js
@@ -1,14 +1,66 @@
 // JsonBeautifier.js
 
-import React from 'react';
+import React, { useState } from 'react';
 
 const JsonBeautifier = () => {
+  const [rawJson, setRawJson] = useState('');
+  const [formattedJson, setFormattedJson] = useState('');
+  const [error, setError] = useState('');
+
+  const handleBeautify = () => {
+    try {
+      const parsed = JSON.parse(rawJson);
+      const pretty = JSON.stringify(parsed, null, 2);
+      setFormattedJson(pretty);
+      setError('');
+    } catch {
+      setError('Invalid JSON');
+      setFormattedJson('');
+    }
+  };
+
+  const handleCopy = async () => {
+    if (formattedJson && navigator.clipboard) {
+      try {
+        await navigator.clipboard.writeText(formattedJson);
+      } catch {
+        // ignore copy errors
+      }
+    }
+  };
+
   return (
     <div>
       <h2>JSON Beautifier</h2>
-      <p>This is the JSON Beautifier page content.</p>
+      <div>
+        <label htmlFor="json-input">JSON Input</label>
+        <textarea
+          id="json-input"
+          value={rawJson}
+          onChange={(e) => setRawJson(e.target.value)}
+          rows={10}
+          cols={50}
+          placeholder="Paste JSON here"
+        ></textarea>
+      </div>
+      <div>
+        <button onClick={handleBeautify}>Beautify JSON</button>
+        {formattedJson && (
+          <button onClick={handleCopy} style={{ marginLeft: '0.5rem' }}>
+            Copy to Clipboard
+          </button>
+        )}
+      </div>
+      {error && (
+        <p role="alert" style={{ color: 'red' }}>
+          {error}
+        </p>
+      )}
+      {formattedJson && (
+        <pre data-testid="formatted-json">{formattedJson}</pre>
+      )}
     </div>
   );
-}
+};
 
 export default JsonBeautifier;

--- a/src/pages/tools/JsonBeautifier.test.js
+++ b/src/pages/tools/JsonBeautifier.test.js
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import JsonBeautifier from './JsonBeautifier';
+
+test('formats valid JSON', () => {
+  render(<JsonBeautifier />);
+  const input = screen.getByLabelText(/JSON Input/i);
+  fireEvent.change(input, { target: { value: '{"a":1}' } });
+  fireEvent.click(screen.getByText(/Beautify JSON/i));
+  const output = screen.getByTestId('formatted-json');
+  expect(output).toHaveTextContent('"a": 1');
+});
+
+test('shows error for invalid JSON', () => {
+  render(<JsonBeautifier />);
+  const input = screen.getByLabelText(/JSON Input/i);
+  fireEvent.change(input, { target: { value: '{invalid}' } });
+  fireEvent.click(screen.getByText(/Beautify JSON/i));
+  expect(screen.getByRole('alert')).toHaveTextContent(/Invalid JSON/i);
+  expect(screen.queryByTestId('formatted-json')).toBeNull();
+});
+
+test('copies formatted JSON to clipboard', () => {
+  Object.assign(navigator, {
+    clipboard: { writeText: jest.fn() },
+  });
+
+  render(<JsonBeautifier />);
+  const input = screen.getByLabelText(/JSON Input/i);
+  fireEvent.change(input, { target: { value: '{"a":1}' } });
+  fireEvent.click(screen.getByText(/Beautify JSON/i));
+  fireEvent.click(screen.getByText(/Copy to Clipboard/i));
+  const expected = JSON.stringify({ a: 1 }, null, 2);
+  expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expected);
+});


### PR DESCRIPTION
## Summary
- add AI playground page that calls OpenAI's chat completions API
- expose playground via sidebar and routing
- include tests for missing API key

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688e6933900483258fb1826e71954b7e